### PR TITLE
_idn_uri_convert() hatası çözümü

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=7.0.0",
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "6.3.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Call to undefined function GuzzleHttp\_idn_uri_convert() hatası çözümü.
Referans: https://github.com/guzzle/guzzle/issues/2502